### PR TITLE
Fix parseBibleReference and narrative strings

### DIFF
--- a/client/src/components/reader/NarrativeMode.tsx
+++ b/client/src/components/reader/NarrativeMode.tsx
@@ -1,9 +1,15 @@
-import React, { useState, useEffect } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Separator } from '@/components/ui/separator';
-import { Book, Camera, Loader2, VideoIcon } from 'lucide-react';
-import { Skeleton } from '@/components/ui/skeleton';
+import React, { useState, useEffect } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Book, Camera, Loader2, VideoIcon } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
 
 interface NarrativeModeProps {
   book: string;
@@ -11,14 +17,18 @@ interface NarrativeModeProps {
   verses: Array<{ number: number; text: string }>;
 }
 
-const NarrativeMode: React.FC<NarrativeModeProps> = ({ book, chapter, verses }) => {
+const NarrativeMode: React.FC<NarrativeModeProps> = ({
+  book,
+  chapter,
+  verses,
+}) => {
   const [isLoading, setIsLoading] = useState(false);
-  const [narrativeText, setNarrativeText] = useState<string>('');
+  const [narrativeText, setNarrativeText] = useState<string>("");
   const [isNarrativeMode, setIsNarrativeMode] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // Combine all verses into a single text for context
-  const fullText = verses?.map(v => v.text).join(' ') || '';
+  const fullText = verses?.map((v) => v.text).join(" ") || "";
 
   const generateNarrative = async () => {
     if (narrativeText) {
@@ -32,24 +42,28 @@ const NarrativeMode: React.FC<NarrativeModeProps> = ({ book, chapter, verses }) 
 
     try {
       const response = await fetch(`/api/ai/narrative/${book}/${chapter}`, {
-        method: 'GET',
+        method: "GET",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
       });
 
       if (!response.ok) {
-        throw new Error('Failed to generate narrative');
+        throw new Error("Failed to generate narrative");
       }
 
       const data = await response.json();
       setNarrativeText(data.content);
       setIsNarrativeMode(true);
     } catch (error) {
-      console.error('Error generating narrative:', error);
-      setError('Failed to generate narrative. Please try again.');
+      console.error("Error generating narrative:", error);
+      setError("Failed to generate narrative. Please try again.");
       // Generate a fallback narrative for demo purposes
-      const fallbackNarrative = generateFallbackNarrative(book, chapter, fullText);
+      const fallbackNarrative = generateFallbackNarrative(
+        book,
+        chapter,
+        fullText,
+      );
       setNarrativeText(fallbackNarrative);
       setIsNarrativeMode(true);
     } finally {
@@ -59,7 +73,7 @@ const NarrativeMode: React.FC<NarrativeModeProps> = ({ book, chapter, verses }) 
 
   // Reset narrative when book/chapter changes
   useEffect(() => {
-    setNarrativeText('');
+    setNarrativeText("");
     setIsNarrativeMode(false);
   }, [book, chapter]);
 
@@ -76,7 +90,9 @@ const NarrativeMode: React.FC<NarrativeModeProps> = ({ book, chapter, verses }) 
       <Button
         onClick={toggleNarrativeMode}
         variant={isNarrativeMode ? "default" : "outline"}
-        className={isNarrativeMode ? "bg-[#2c4c3b] hover:bg-[#1a3329] text-white" : ""}
+        className={
+          isNarrativeMode ? "bg-[#2c4c3b] hover:bg-[#1a3329] text-white" : ""
+        }
         disabled={isLoading}
       >
         {isLoading ? (
@@ -124,11 +140,9 @@ const NarrativeMode: React.FC<NarrativeModeProps> = ({ book, chapter, verses }) 
               </div>
             ) : (
               <div className="prose prose-green dark:prose-invert max-w-none">
-                {error && (
-                  <p className="text-red-500 text-sm mb-2">{error}</p>
-                )}
+                {error && <p className="text-red-500 text-sm mb-2">{error}</p>}
                 <div className="narrative-text leading-relaxed font-serif">
-                  {narrativeText.split('\n\n').map((paragraph, idx) => (
+                  {narrativeText.split("\n\n").map((paragraph, idx) => (
                     <p key={idx}>{paragraph}</p>
                   ))}
                 </div>
@@ -142,17 +156,21 @@ const NarrativeMode: React.FC<NarrativeModeProps> = ({ book, chapter, verses }) 
 };
 
 // Helper function to generate a fallback narrative for demo purposes
-const generateFallbackNarrative = (book: string, chapter: number, originalText: string): string => {
-  let narrativeIntro = '';
-  
+const generateFallbackNarrative = (
+  book: string,
+  chapter: number,
+  originalText: string,
+): string => {
+  let narrativeIntro = "";
+
   // Customize the intro based on the book
-  if (book.toLowerCase() === 'genesis' && chapter === 1) {
+  if (book.toLowerCase() === "genesis" && chapter === 1) {
     narrativeIntro = `The vast expanse of nothingness stretched before God, a canvas waiting for His touch. There was no light, no form, only the Spirit of God hovering expectantly over the deep waters of potential. The Director of all creation prepared to speak the first words of existence into being.
 
 Mary, her eyes wide with wonder, leaned in closer to Jesus as He continued the story she had heard since childhood, yet now told by the very Author of creation Himself.
 
 "In the beginning," Jesus said, His voice resonant with authority yet gentle, "when there was nothing—no stars, no earth, no creatures—my Father spoke." He paused, His eyes reflecting something ancient and profound. "And everything changed."`;
-  } else if (book.toLowerCase() === 'john' && chapter === 1) {
+  } else if (book.toLowerCase() === "john" && chapter === 1) {
     narrativeIntro = `The cool evening air settled over Ephesus as John, now elderly with weathered hands and deep lines etched across his face, sat surrounded by his disciples. His eyes, though dimmed with age, still burned with the fire of one who had witnessed the extraordinary. He dipped his pen and began to write, the words flowing from a place beyond mere memory.
 
 "In the beginning was the Word," he wrote, his hand steady despite his years. "And the Word was with God, and the Word was God."
@@ -166,33 +184,40 @@ John's eyes grew distant, seeing beyond the small room to that day by the Jordan
 
 As the narrative of ${book} chapter ${chapter} unfolded, the listeners were transported across time, walking alongside those who had lived these sacred stories. The divine inspiration behind the text revealed itself not just in the wisdom of the words, but in their power to transform hearts centuries after they were first written.`;
   }
-  
+
   // Return the intro followed by a narrative adaptation of the original text
   return `${narrativeIntro}\n\n${adaptTextToNarrative(book, chapter, originalText)}`;
 };
 
 // Helper function to convert standard Bible text to narrative style
-const adaptTextToNarrative = (book: string, chapter: number, text: string): string => {
+const adaptTextToNarrative = (
+  book: string,
+  chapter: number,
+  text: string,
+): string => {
   // Remove verse numbers and transform to narrative style
   let narrative = text
-    .replace(/^\d+\s+/gm, '') // Remove verse numbers
-    .replace(/And it came to pass/g, 'It happened')
-    .replace(/And God said/g, 'God spoke, His voice resonating through the formless void')
-    .replace(/And God saw/g, 'God beheld His work')
-    .replace(/behold/gi, 'look')
-    .replace(/unto/g, 'to')
-    .replace(/Thus saith the Lord/gi, 'The Lord declared')
-    .replace(/thy/g, 'your')
-    .replace(/thou/g, 'you')
-    .replace(/thee/g, 'you');
-  
+    .replace(/^\d+\s+/gm, "") // Remove verse numbers
+    .replace(/And it came to pass/g, "It happened")
+    .replace(
+      /And God said/g,
+      "God spoke, His voice resonating through the formless void",
+    )
+    .replace(/And God saw/g, "God beheld His work")
+    .replace(/behold/gi, "look")
+    .replace(/unto/g, "to")
+    .replace(/Thus saith the Lord/gi, "The Lord declared")
+    .replace(/thy/g, "your")
+    .replace(/thou/g, "you")
+    .replace(/thee/g, "you");
+
   // Add narrative elements based on book
-  if (book.toLowerCase() === 'genesis') {
-    narrative += '\n\nThe creation narrative continued to unfold as God spoke galaxies into existence with the same ease we might speak a greeting. The ancient storyteller's words barely captured the magnitude of these moments—how could language contain the birth of everything? Yet through these humble phrases, generations would connect to their Creator and find their place in His story.';
-  } else if (book.toLowerCase() === 'john') {
-    narrative += '\n\nThe disciples exchanged glances, only beginning to grasp the weight of what they were witnessing. They were not merely following a teacher; they were walking with the very Word that had been present since before time began. The Word that had now taken on flesh and made His dwelling among them, full of grace and truth.';
+  if (book.toLowerCase() === "genesis") {
+    narrative += `\n\nThe creation narrative continued to unfold as God spoke galaxies into existence with the same ease we might speak a greeting. The ancient storyteller's words barely captured the magnitude of these moments—how could language contain the birth of everything? Yet through these humble phrases, generations would connect to their Creator and find their place in His story.`;
+  } else if (book.toLowerCase() === "john") {
+    narrative += `\n\nThe disciples exchanged glances, only beginning to grasp the weight of what they were witnessing. They were not merely following a teacher; they were walking with the very Word that had been present since before time began. The Word that had now taken on flesh and made His dwelling among them, full of grace and truth.`;
   }
-  
+
   return narrative;
 };
 

--- a/client/src/lib/bibleService.js
+++ b/client/src/lib/bibleService.js
@@ -2,7 +2,11 @@
  * Bible text and features service
  * Handles retrieval, caching, and transformation of Bible text and related features
  */
-import { fetchBibleChapter, fetchChapterContext, fetchCrossReferences } from './api';
+import {
+  fetchBibleChapter,
+  fetchChapterContext,
+  fetchCrossReferences,
+} from "./api";
 
 // Local cache to avoid unnecessary API calls
 const chapterCache = new Map();
@@ -17,17 +21,17 @@ const crossReferenceCache = new Map();
  */
 export async function getBibleChapter(book, chapter) {
   const cacheKey = `${book.toLowerCase()}_${chapter}`;
-  
+
   if (chapterCache.has(cacheKey)) {
     return chapterCache.get(cacheKey);
   }
-  
+
   try {
     const chapterData = await fetchBibleChapter(book, chapter);
     chapterCache.set(cacheKey, chapterData);
     return chapterData;
   } catch (error) {
-    console.error('Error fetching Bible chapter:', error);
+    console.error("Error fetching Bible chapter:", error);
     throw error;
   }
 }
@@ -40,17 +44,17 @@ export async function getBibleChapter(book, chapter) {
  */
 export async function getChapterContext(book, chapter) {
   const cacheKey = `${book.toLowerCase()}_${chapter}`;
-  
+
   if (contextCache.has(cacheKey)) {
     return contextCache.get(cacheKey);
   }
-  
+
   try {
     const contextData = await fetchChapterContext(book, chapter);
     contextCache.set(cacheKey, contextData);
     return contextData;
   } catch (error) {
-    console.error('Error fetching chapter context:', error);
+    console.error("Error fetching chapter context:", error);
     throw error;
   }
 }
@@ -63,17 +67,17 @@ export async function getChapterContext(book, chapter) {
  */
 export async function getChapterCrossReferences(book, chapter) {
   const cacheKey = `${book.toLowerCase()}_${chapter}`;
-  
+
   if (crossReferenceCache.has(cacheKey)) {
     return crossReferenceCache.get(cacheKey);
   }
-  
+
   try {
     const crossRefs = await fetchCrossReferences(book, chapter);
     crossReferenceCache.set(cacheKey, crossRefs);
     return crossRefs;
   } catch (error) {
-    console.error('Error fetching cross references:', error);
+    console.error("Error fetching cross references:", error);
     throw error;
   }
 }
@@ -86,7 +90,9 @@ export async function getChapterCrossReferences(book, chapter) {
  */
 export function getVerseFromChapter(chapterData, verseNumber) {
   if (!chapterData || !chapterData.verses) return null;
-  return chapterData.verses.find(verse => verse.verse === verseNumber) || null;
+  return (
+    chapterData.verses.find((verse) => verse.verse === verseNumber) || null
+  );
 }
 
 /**
@@ -94,15 +100,15 @@ export function getVerseFromChapter(chapterData, verseNumber) {
  * @param {string} book - The book name
  * @param {number} chapter - The chapter number
  * @param {number} startVerse - Starting verse number
- * @param {number} endVerse - Ending verse number 
+ * @param {number} endVerse - Ending verse number
  * @returns {Promise<Array>} - Array of verses in the range
  */
 export async function getVerseRange(book, chapter, startVerse, endVerse) {
   const chapterData = await getBibleChapter(book, chapter);
   if (!chapterData || !chapterData.verses) return [];
-  
+
   return chapterData.verses.filter(
-    verse => verse.verse >= startVerse && verse.verse <= endVerse
+    (verse) => verse.verse >= startVerse && verse.verse <= endVerse,
   );
 }
 
@@ -127,16 +133,16 @@ export function formatBibleReference(book, chapter, verse) {
  */
 export function parseBibleReference(reference) {
   try {
-    const [book, chapterVerse] = reference.split(' ');
-    const [chapter, verse] = chapterVerse.split(':');
-    
-    return {
-      book,
-      chapter: parseInt(chapter, 10),
-      verse: verse ? parseInt(verse, 10) : null
-    };
+    const match = reference.trim().match(/^(.*\D)\s+(\d+)(?::(\d+))?$/);
+    if (!match) return null;
+
+    const book = match[1];
+    const chapter = parseInt(match[2], 10);
+    const verse = match[3] ? parseInt(match[3], 10) : null;
+
+    return { book, chapter, verse };
   } catch (error) {
-    console.error('Error parsing Bible reference:', error);
+    console.error("Error parsing Bible reference:", error);
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- escape apostrophe in `NarrativeMode` narrative strings
- make `parseBibleReference` handle multi‑word book names

## Testing
- `pnpm tsc --noEmit` *(fails: Cannot find type definition file for 'node')*
- `node scripts/dup-check.js` *(fails: Duplicate readers detected)*