### PR TITLE
Fix cross-reference lookup with lowercase book names

### DIFF
--- a/server/routes/cross-references.ts
+++ b/server/routes/cross-references.ts
@@ -177,8 +177,10 @@ router.get('/:book/:chapter/:verse', async (req: Request, res: Response) => {
       return res.status(400).json({ message: 'Invalid chapter or verse number' });
     }
     
+    // Normalize book name to match the format used in the chapter route
+    const bookName = book.charAt(0).toUpperCase() + book.slice(1).toLowerCase();
     // Construct verse reference
-    const fromRef = `${book} ${chapter}:${verse}`;
+    const fromRef = `${bookName} ${chapter}:${verse}`;
     
     // Get related references from the DB (or use default for testing)
     const relatedRefs = crossReferenceDB[fromRef] || crossReferenceDB['default'];


### PR DESCRIPTION
## Summary
- capitalize book names in the cross-reference verse route
- ensure requests with lowercase book names resolve correctly

## Testing
- `npm run check` *(fails: NarrativeMode.tsx errors)*
- `node` script to verify lookup works for lowercase book names