### PR TITLE
Add cross references API test skeleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "node --test"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.37.0",

--- a/server/tests/cross-references.test.js
+++ b/server/tests/cross-references.test.js
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import { registerRoutes } from '../routes';
+import request from 'supertest';
+
+const app = express();
+app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
+
+await registerRoutes(app);
+
+test('lowercase book name returns cross references', async () => {
+  const res = await request(app).get('/api/reader/cross-references/genesis/1/1');
+  assert.equal(res.status, 200);
+  assert.ok(Array.isArray(res.body));
+  assert.ok(res.body.length > 0);
+});


### PR DESCRIPTION
## Summary
- add basic test for `/api/reader/cross-references/:book/:chapter/:verse`
- hook up `pnpm test` to Node's test runner

## Testing
- `pnpm test` *(fails: Cannot find module 'express')*