### PR TITLE
Fix duplicate verse tag check

### DIFF
--- a/scripts/verse-tag-manual-test.js
+++ b/scripts/verse-tag-manual-test.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+/**
+ * Manual test to verify duplicate verse-tag pairs are not created.
+ * This script simulates inserting the same tag for a verse twice and
+ * checks that only one association is stored.
+ */
+
+const verseTags = [];
+
+function addTagToVerse(verseId, tagId) {
+  const existing = verseTags.find(vt => vt.verseId === verseId && vt.tagId === tagId);
+  if (!existing) {
+    verseTags.push({ verseId, tagId });
+  }
+}
+
+// Add the same pair twice
+addTagToVerse('v1', 't1');
+addTagToVerse('v1', 't1');
+
+// Expect only one entry
+const result = verseTags.filter(vt => vt.verseId === 'v1' && vt.tagId === 't1');
+console.log('Associations found:', result.length);
+console.log(result);
+

--- a/server/bible-cache.ts
+++ b/server/bible-cache.ts
@@ -207,8 +207,10 @@ export async function saveTagsToDatabase(reference: string, verseTags: VerseTags
           .select()
           .from(verseTags)
           .where(
-            eq(verseTags.verseId, verse.id),
-            eq(verseTags.tagId, existingTag.id)
+            and(
+              eq(verseTags.verseId, verse.id),
+              eq(verseTags.tagId, existingTag.id)
+            )
           );
 
         // If relationship doesn't exist, create it


### PR DESCRIPTION
## Summary
- prevent duplicate verse/tag pair creation
- add manual test script for verse tag duplicates

## Testing
- `npm run check` *(fails: NarrativeMode.tsx TS errors)*