### PR TITLE
Add Vercel deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: Deploy
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: .
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,0 +1,39 @@
+import express, { Request, Response, NextFunction } from 'express';
+import { registerRoutes } from '../server/routes';
+import { serveStatic, log } from '../server/vite';
+import { initBibleRAG } from '../server/rag-bible';
+
+const app = express();
+app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
+
+let initPromise: Promise<void> | null = null;
+async function ensureInitialized() {
+  if (!initPromise) {
+    initPromise = (async () => {
+      try {
+        await initBibleRAG();
+        log('Bible RAG system initialized successfully', 'vercel');
+      } catch (error) {
+        log(`Error initializing Bible RAG system: ${error}`, 'vercel');
+      }
+
+      await registerRoutes(app);
+
+      app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+        const status = err.status || err.statusCode || 500;
+        const message = err.message || 'Internal Server Error';
+        res.status(status).json({ message });
+        throw err;
+      });
+
+      serveStatic(app);
+    })();
+  }
+  return initPromise;
+}
+
+export default async function handler(req: Request, res: Response) {
+  await ensureInitialized();
+  return app(req, res);
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && esbuild server/index.ts api/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "version": 2,
+  "buildCommand": "pnpm build",
+  "outputDirectory": "dist",
+  "routes": [
+    { "src": "/(.*)", "dest": "api/index.js" }
+  ]
+}


### PR DESCRIPTION
## Summary
- create serverless entrypoint for Vercel
- output serverless build in package build script
- add Vercel project settings
- add GitHub Actions deploy workflow

## Testing
- `node scripts/dup-check.js` *(fails: Duplicate readers detected)*
- `pnpm tsc --noEmit` *(fails: several type errors)*
- `pnpm build`