### PR TITLE
Fix server allowedHosts option

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -23,7 +23,7 @@ export async function setupVite(app: Express, server: Server) {
   const serverOptions = {
     middlewareMode: true,
     hmr: { server },
-    allowedHosts: true,
+    allowedHosts: true as const,
   };
 
   const vite = await createViteServer({


### PR DESCRIPTION
## Summary
- update Vite server config so `allowedHosts` is a literal

## Testing
- `npm run build`
- `npm run check` *(fails: server/storage.ts etc.)*