### PR TITLE
Fix isBookmarked mismatch

### DIFF
--- a/client/src/lib/bibleData.ts
+++ b/client/src/lib/bibleData.ts
@@ -18,7 +18,6 @@ export interface BibleChapter {
     genz?: string;
     kids?: string;
     novelize?: string;
-    isBookmarked?: boolean;
     hasNote?: boolean;
     highlightColor?: string;
   }[];

--- a/server/routes/bible-reader.ts
+++ b/server/routes/bible-reader.ts
@@ -81,7 +81,6 @@ router.get('/:book/:chapter', async (req: Request, res: Response) => {
         kjv: cachedVerse?.kjv || dbVerse.text,
         web: cachedVerse?.web || dbVerse.text,
         // Add user-specific data
-        isBookmarked: !!userNote?.isBookmarked,
         hasNote: !!userNote?.content,
         highlightColor: userNote?.highlightColor
       };

--- a/server/routes/genesis-reader.ts
+++ b/server/routes/genesis-reader.ts
@@ -191,9 +191,8 @@ router.get('/:chapter', async (req: Request, res: Response) => {
           verse: i,
           number: i,
           text: webText || `Genesis ${chapterNum}:${i}`,
-          textKjv: kjvText || `Genesis ${chapterNum}:${i} (KJV)`,  
+          textKjv: kjvText || `Genesis ${chapterNum}:${i} (KJV)`,
           textWeb: webText || `Genesis ${chapterNum}:${i} (WEB)`,
-          isBookmarked: metadata.isBookmarked || false,
           hasNote: metadata.hasNote || false,
           tags: metadata.tags || {}
         });


### PR DESCRIPTION
## Summary
- remove `isBookmarked` usage from bible reader routes
- update BibleChapter type

## Testing
- `npm test` *(fails: ERR_UNSUPPORTED_DIR_IMPORT in cross-references.test.js)*