### PR TITLE
Add array type annotations

### DIFF
--- a/server/routes/cross-references.ts
+++ b/server/routes/cross-references.ts
@@ -68,7 +68,7 @@ function generateMockCrossReferences(reference: string): CrossReference[] {
     // Generate tags
     const allTags = ['creation', 'word', 'beginning', 'faith', 'power', 'love', 'redemption', 'glory', 'wisdom'];
     const numTags = Math.floor(Math.random() * 3) + 1; // 1-3 tags
-    const tags = [];
+    const tags: string[] = [];
     for (let i = 0; i < numTags; i++) {
       const tag = allTags[Math.floor(Math.random() * allTags.length)];
       if (!tags.includes(tag)) {
@@ -144,7 +144,7 @@ router.get('/chapter/:book/:chapter', async (req: Request, res: Response) => {
     
     // In a production app, this would query the database for all cross-references
     // where either fromRef or toRef is in this chapter
-    const crossRefs = [];
+    const crossRefs: CrossReference[] = [];
     
     // Create a few cross-references for the chapter
     const bookName = book.charAt(0).toUpperCase() + book.slice(1).toLowerCase();
@@ -334,7 +334,7 @@ function getCommonThemes(fromRef: string, toRef: string): string[] {
   
   // Return 2-4 random themes
   const numThemes = Math.floor(Math.random() * 3) + 2; // 2-4
-  const selectedThemes = [];
+  const selectedThemes: string[] = [];
   
   for (let i = 0; i < numThemes; i++) {
     const theme = allThemes[Math.floor(Math.random() * allThemes.length)];

--- a/server/routes/genesis-reader.ts
+++ b/server/routes/genesis-reader.ts
@@ -5,6 +5,17 @@ import path from 'path';
 
 const router = Router();
 
+interface GenesisVerse {
+  verse: number;
+  number: number;
+  text: string;
+  textKjv: string;
+  textWeb: string;
+  isBookmarked: boolean;
+  hasNote: boolean;
+  tags: Record<string, any>;
+}
+
 // Get Genesis chapter data from our enriched files
 router.get('/:chapter', async (req: Request, res: Response) => {
   try {
@@ -137,7 +148,7 @@ router.get('/:chapter', async (req: Request, res: Response) => {
       }
       
       // Create the complete array of verses
-      const verses = [];
+      const verses: GenesisVerse[] = [];
       
       // Create a map of full text verses if available
       const fullTextMap = new Map();

--- a/server/routes/rag-explorer.ts
+++ b/server/routes/rag-explorer.ts
@@ -71,8 +71,8 @@ router.get('/tag/:book/:type/:value', async (req: Request, res: Response) => {
     }
     
     // Look through the Genesis chapters data directly for now
-    try {
-      const chapters = [];
+      try {
+      const chapters: any[] = [];
       
       // We'll check the first 12 chapters of Genesis in our current implementation
       for (let chapterNum = 1; chapterNum <= 12; chapterNum++) {
@@ -94,7 +94,7 @@ router.get('/tag/:book/:type/:value', async (req: Request, res: Response) => {
       }
       
       // Find verses that contain this tag
-      const matchingVerses = [];
+      const matchingVerses: any[] = [];
       
       for (const chapter of chapters) {
         for (const verse of chapter.verses) {
@@ -210,8 +210,8 @@ router.get('/related/:book/:chapter/:verse', async (req: Request, res: Response)
       const symbolsToMatch = verseTags.symbols || [];
       
       // Find verses that share these tags
-      const relatedVerses = [];
-      const chaptersToSearch = [];
+      const relatedVerses: any[] = [];
+      const chaptersToSearch: any[] = [];
       
       // Get nearby chapters (for context)
       for (let c = Math.max(1, chapterNum - 2); c <= Math.min(50, chapterNum + 2); c++) {
@@ -317,8 +317,8 @@ router.get('/concept-map/:book/:chapter?', async (req: Request, res: Response) =
       const ragIndex = JSON.parse(await readFile(indexPath, 'utf8'));
       
       // Build concept map nodes and edges
-      const nodes = [];
-      const edges = [];
+      const nodes: any[] = [];
+      const edges: any[] = [];
       
       // Add theme nodes
       ragIndex.themes.forEach((theme, idx) => {


### PR DESCRIPTION
## Summary
- specify string array for tags and selected themes in cross-references route
- type the crossRefs array in cross-references route
- define `GenesisVerse` interface and type the `verses` array in genesis reader
- annotate temporary arrays in rag explorer route

## Testing
- `npm run check` *(fails: Typescript errors in unrelated files)*