### PR TITLE
Fix Vercel api static issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts api/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && esbuild server/index.ts api/index.ts --platform=node --packages=external --bundle --format=esm --outdir=.",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,9 @@
 {
   "version": 2,
   "buildCommand": "pnpm build",
-  "outputDirectory": "dist",
+  "outputDirectory": "dist/public",
   "routes": [
-    { "src": "/(.*)", "dest": "api/index.js" }
+    { "src": "/api/(.*)", "dest": "api/index.js" },
+    { "src": "/(.*)", "dest": "dist/public/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- adjust build script so api build lands outside of `dist`
- keep static assets under `dist/public`
- route API requests separately and fall through to SPA index

## Testing
- `pnpm build`
- `pnpm test` *(fails: ERR_UNSUPPORTED_DIR_IMPORT)*