### PR TITLE
Fix React 19 conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "@radix-ui/react-toggle": "^1.1.3",
     "@radix-ui/react-toggle-group": "^1.1.3",
     "@radix-ui/react-tooltip": "^1.2.0",
+    "@react-three/fiber": "8.13.7",
+    "@react-spring/native": "9.7.2",
+    "@react-spring/three": "9.7.2",
     "@tanstack/react-query": "^5.60.5",
     "@types/memoizee": "^0.4.12",
     "@types/uuid": "^10.0.0",
@@ -71,13 +74,14 @@
     "openid-client": "^6.5.0",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
-    "react": "^19.1.0",
+    "react": "18.3.1",
     "react-day-picker": "^8.10.1",
-    "react-dom": "^19.1.0",
+    "react-dom": "18.3.1",
     "react-force-graph": "^1.47.6",
     "react-force-graph-2d": "^1.27.1",
     "react-hook-form": "^7.55.0",
     "react-icons": "^5.5.0",
+    "react-konva": "18.1.0",
     "react-pdf": "^9.2.1",
     "react-resizable-panels": "^2.1.7",
     "react-router-dom": "^7.6.0",
@@ -121,5 +125,9 @@
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"
+  },
+  "overrides": {
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- pin `react` and `react-dom` to v18
- add overrides to force React 18 across dependencies
- add R3F, React Spring, and react-konva packages compatible with React 18

## Testing
- `npm --version`